### PR TITLE
Enable level debugger for 2.4 playtesting

### DIFF
--- a/Source/playtestthread.lua
+++ b/Source/playtestthread.lua
@@ -161,7 +161,8 @@ else
 	-- Version 2.4 or later
 	args = {
 		"-p",
-		"special/stdin"
+		"special/stdin",
+		"-leveldebugger"
 	}
 end
 


### PR DESCRIPTION
2.4 was released today, containing the level debugger, which can be enabled using a flag. This commit adds it to the 2.4-exclusive arguments.