### PR TITLE
Fix warnings on LÖVE 12

### DIFF
--- a/Source/coretext.lua
+++ b/Source/coretext.lua
@@ -177,7 +177,7 @@ end
 
 function unloadlanguage()
 	-- Prepare for language change
-	package.loaded["lang/" .. s.lang] = false
+	package.loaded["lang." .. s.lang] = false
 	package.loaded.devstrings = false
 end
 

--- a/Source/filefunc_win.lua
+++ b/Source/filefunc_win.lua
@@ -1,7 +1,7 @@
 local cache_modtimes = {} -- filepath => unix_timestamp
 
 
-require("libs/windows_constants")
+require("libs.windows_constants")
 
 local ffi = require("ffi")
 local shell32 = ffi.load("Shell32") -- SHGetFolderPathW

--- a/Source/func.lua
+++ b/Source/func.lua
@@ -3150,7 +3150,7 @@ function unload_uis()
 
 	for k,v in pairs(uis) do
 		for k2,v2 in pairs(v) do
-			local name = v.path .. k2
+			local name = (v.path .. k2):gsub("/", ".")
 			if package.loaded[name] then
 				package.loaded[name] = false
 			end

--- a/Source/https_win.lua
+++ b/Source/https_win.lua
@@ -1,4 +1,4 @@
-require("libs/windows_constants")
+require("libs.windows_constants")
 
 local ffi = require("ffi")
 local wininet = ffi.load("wininet")

--- a/Source/love11compat.lua
+++ b/Source/love11compat.lua
@@ -25,6 +25,7 @@ love.graphics.setBackgroundColor = function(r,g,b,a)
 	love.graphics.setBackgroundColor11(r/255, g/255, b/255, (a or 255) / 255)
 end
 
+love.filesystem.exists12 = love.filesystem.exists -- Keep this around for the love12compat file
 love.filesystem.exists = function(filename)
 	return love.filesystem.getInfo(filename) ~= nil
 end

--- a/Source/love12compat.lua
+++ b/Source/love12compat.lua
@@ -1,0 +1,3 @@
+-- Compatibility with love2d 12.x and above
+
+love.filesystem.exists = love.filesystem.exists12

--- a/Source/main.lua
+++ b/Source/main.lua
@@ -56,7 +56,11 @@ function dodisplaysettings(reload)
 		local zwidth,zheight = love.window.getDesktopDimensions(zf)
 		zc.x = (zwidth-za*s.pscale)/2
 		zc.y = (zheight-zb*s.pscale)/2
-		zc.display = zf
+		if (love_version_meets(12)) then
+			zc.displayindex = zf
+		else
+			zc.display = zf
+		end
 	end
 	love.window.setMode(za*s.pscale,zb*s.pscale,zc)
 
@@ -115,6 +119,10 @@ else
 
 		if love_version_meets(11) then
 			require("love11compat")
+
+			if love_version_meets(12) then
+				require("love12compat")
+			end
 		end
 	end
 	require("errorhandler")

--- a/Source/mapfunc.lua
+++ b/Source/mapfunc.lua
@@ -247,7 +247,9 @@ function map_export(x1, y1, w, h, resolution, transparentbg)
 
 		local saveas = ((editingmap == "untitled\n" and "untitled" or editingmap) .. "_" .. os.time() .. ".png"):gsub(dirsep, "__")
 
-		if love_version_meets(10) then
+		if love_version_meets(12) then
+			love.graphics.readbackTexture(canvas):encode("png", "maps/" .. saveas)
+		elseif love_version_meets(10) then
 			canvas:newImageData():encode("png", "maps/" .. saveas)
 		else
 			canvas:getImageData():encode("maps/" .. saveas)


### PR DESCRIPTION
Since LÖVE 12 shows warnings on boot, this commit gets rid of them, while still keeping compatibility with earlier versions of LÖVE.