### PR TITLE
Clean up command autocomplete

### DIFF
--- a/Source/scriptfunc.lua
+++ b/Source/scriptfunc.lua
@@ -1309,3 +1309,33 @@ function delete_script(script_i)
 	-- We might have removed a script reference, so update usages
 	usedscripts, n_usedscripts = find_used_scripts()
 end
+
+function get_valid_commands()
+	-- Get the commands for this context.
+	local commands = {}
+
+	local internal = (internalscript or cutscenebarsinternalscript)
+
+	for command, _ in pairs(internal and knowninternalcommands or knowncommands) do
+		table.insert(commands, command)
+	end
+
+	return commands
+end
+
+function get_autocomplete_commands(command_part)
+	-- Return a sorted list of commands that start with command_part
+	local commands = {}
+	for _, command in pairs(get_valid_commands()) do
+		if command:sub(1, #command_part) == command_part then
+			table.insert(commands, command)
+		end
+	end
+
+	-- Sort the commands by their length
+	table.sort(commands, function(a, b)
+		return utf8.len(a) < utf8.len(b)
+	end)
+
+	return commands
+end

--- a/Source/scriptfunc.lua
+++ b/Source/scriptfunc.lua
@@ -1326,8 +1326,9 @@ end
 function get_autocomplete_commands(command_part)
 	-- Return a sorted list of commands that start with command_part
 	local commands = {}
+	local part_len = command_part:len()
 	for _, command in pairs(get_valid_commands()) do
-		if command:sub(1, #command_part) == command_part then
+		if command:sub(1, part_len) == command_part then
 			table.insert(commands, command)
 		end
 	end

--- a/Source/uis/scripteditor/keypressed.lua
+++ b/Source/uis/scripteditor/keypressed.lua
@@ -48,8 +48,6 @@ return function(key)
 			dirty()
 		end
 	elseif key == "tab" then
-		local matching = {}
-
 		local line_x, editing_line = newinputsys.getpos("script_lines")
 		local command_part = utf8.sub(inputs.script_lines[editing_line], 1, line_x)
 
@@ -57,29 +55,13 @@ return function(key)
 			return
 		end
 
-		for k,v in pairs(knowncommands) do
-			if k:sub(1, command_part:len()) == command_part then
-				table.insert(matching, k)
-			end
-		end
-		for k,v in pairs(knowninternalcommands) do
-			if k:sub(1, command_part:len()) == command_part and not table.contains(matching, k) then
-				table.insert(matching, k)
-			end
-		end
-
-		local shortest_match = nil
-		for k,v in pairs(matching) do
-			if v ~= command_part and (shortest_match == nil or v:len() < shortest_match:len()) then
-				shortest_match = v
-			end
-		end
-		if shortest_match == nil then
+		local commands = get_autocomplete_commands(command_part)
+		if #commands == 0 then
 			return
 		end
 
 		local oldstate = {newinputsys.getstate("script_lines")}
-		newinputsys.insertchars("script_lines", shortest_match:sub(command_part:len()+1))
+		newinputsys.insertchars("script_lines", commands[1]:sub(command_part:len()+1))
 		newinputsys.unre("script_lines", UNRE.INSERT, unpack(oldstate))
 	elseif key == "escape" then
 		local success, raw_script = script_compile(inputs.script_lines)


### PR DESCRIPTION
I thought it'd be better to abstract this functionality to a few functions in scriptfunc, for if a plugin wants to hook the list of commands cleanly (ex. fakecommands) or would like to get a list of autocomplete commands without copy-pasting the code (which would work well with, again, plugins hooking the list of possible commands).