### PR TITLE
Add simple "entity display" to some commands

### DIFF
--- a/Source/scriptfunc.lua
+++ b/Source/scriptfunc.lua
@@ -459,6 +459,43 @@ function script_context(text, textlinestogo)
 			end
 			return "track", track, nil, nil
 		end
+	elseif table.contains({"changecolour", "changeplayercolour", "changerespawncolour"}, parts[1]) then
+		-- Simple "crewmate with color" display
+
+		if parts[2] == nil then
+			return nil
+		end
+
+		if parts[1] == "changecolour" then
+			-- Second argument is the color
+			return "entity", 0, get_createcrewman_r(parts[3]), nil
+		end
+
+		-- First argument is the color
+		return "entity", 0, get_createcrewman_r(parts[2]), nil
+	elseif table.contains({"textsprite", "changetile"}, parts[1]) then
+		-- Slightly more complicated "entity" display
+
+		local color = 0
+		local tile = 0
+
+		if parts[1] == "changetile" then
+			if parts[2] == nil then
+				return nil, nil, nil, nil
+			end
+
+			color = get_createcrewman_r(parts[2])
+			tile = anythingbutnil0(parts[3])
+		elseif parts[1] == "textsprite" then
+			if parts[2] == nil or parts[3] == nil or parts[4] == nil then
+				return nil, nil, nil, nil
+			end
+
+			color = get_createcrewman_r(parts[5])
+			tile = anythingbutnil0(parts[4])
+		end
+
+		return "entity", tile, color, nil
 	else
 		return nil, nil, nil, nil
 	end

--- a/Source/uis/scripteditor/draw.lua
+++ b/Source/uis/scripteditor/draw.lua
@@ -615,5 +615,20 @@ return function()
 				)
 			end
 		end
+	elseif context == "entity" then
+		-- Sane "VVVVVVish" defaults
+		local tile = anythingbutnil0(carg1)
+		local color = anythingbutnil0(carg2)
+
+		local x = love.graphics.getWidth() - (128 - 8) + 24
+		local y = 8 + (24 * 12) + 4
+
+		v6_setcol(color)
+
+		drawentitysprite(tile, x, y)
+
+		love.graphics.setColor(128,128,128)
+		love.graphics.rectangle("line", x - .5, y - .5, 64, 64)
+		love.graphics.setColor(255,255,255)
 	end
 end


### PR DESCRIPTION
`changecolour`, `changeplayercolour`, `changerespawncolour`, `textsprite` and `changetile` now have a "script context" display in the bottom-right of the script editor while you're writing the commands.

It displays a `sprites.png` tile (in the case of the color-changing commands, it's always tile 0, for a crewmate) in a certain color (ID).

It displays the whole 32x32 tile in a box, and there's nothing special for crewmates (ex. what does it look like flipped, or walking, or facing left?) but that can come later. This is mostly useful for `changetile`, as it's a good way to preview tiles.

In the future, it'd be neat to have some "context settings", like, "make the preview show a crewmate walking", or "what does this tile look like applied to a terminal", but this is good for now IMO.